### PR TITLE
Remove usage of deprecated setuptools features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ See the [InfoCenter](https://infocenter.nordicsemi.com/topic/ug_nrfutil/UG/nrfut
 
 Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 
+## Tests
+
+Unittests can be ran from project root directory with `python -m unittest discover -s test`.
+
 ## Contributing
 
 Feel free to propose changes by creating a pull request.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,2 @@
 -r requirements.txt
-behave
-nose
 pyinstaller

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ import os
 import sys
 
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
 from nordicsemi import version
 
@@ -123,17 +122,6 @@ with open("requirements.txt") as reqs_file:
     reqs = reqs_file.readlines()
 
 
-class NoseTestCommand(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import nose
-        nose.run_exit(argv=['nosetests', '--with-xunit', '--xunit-file=unittests.xml'])
-
-
 setup(
     name="nrfutil",
     version=version.NRFUTIL_VERSION,
@@ -151,10 +139,6 @@ setup(
     python_requires='>=3.7, <3.11',
     install_requires=reqs,
     zipfile=None,
-    tests_require=[
-        "nose >= 1.3.4",
-        "behave"
-    ],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -177,9 +161,6 @@ setup(
         'Programming Language :: Python :: 3.10',
     ],
     keywords='nordic nrf51 nrf52 ble bluetooth dfu ota softdevice serialization nrfutil pc-nrfutil',
-    cmdclass={
-        'test': NoseTestCommand
-    },
     entry_points='''
       [console_scripts]
       nrfutil = nordicsemi.__main__:cli


### PR DESCRIPTION
Remove usage of setuptools.command.test and setuptools tests_require which are deprecated in setuptools 72.0.0. Remove also usage of nose.