### PR TITLE
setup: relax python version requirements to let user decide upper limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ intelhex
 libusb1>=1.9.3
 pc_ble_driver_py >= 0.16.4
 piccata
-protobuf >=3.17.3, < 4.0.0
+protobuf >=3.17.3, < 5.0.0
 pyserial
 pyspinel >= 1.0.0a3
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ intelhex
 libusb1>=1.9.3
 pc_ble_driver_py >= 0.16.4
 piccata
-protobuf >=3.17.3, < 5.0.0
+protobuf >=3.17.3
 pyserial
 pyspinel >= 1.0.0a3
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click
 crcmod
 ecdsa
 intelhex
-libusb1==1.9.3
+libusb1>=1.9.3
 pc_ble_driver_py >= 0.16.4
 piccata
 protobuf >=3.17.3, < 4.0.0

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
                      '../libusb/x86/libusb-1.0.dll', '../libusb/x64/libusb-1.0.dll',
                      '../libusb/x64/libusb-1.0.dylib', '../libusb/LICENSE']
     },
-    python_requires='>=3.7, <3.11',
+    python_requires='>=3.7',
     install_requires=reqs,
     zipfile=None,
     tests_require=[


### PR DESCRIPTION
The python 3.12 has been out for a year. Let's just remove the forced Python version upper limit and let the user to decide what version to use.